### PR TITLE
fix: do not halt the script if a vcf file is not found

### DIFF
--- a/server/init.lua
+++ b/server/init.lua
@@ -23,7 +23,7 @@ AddEventHandler('onResourceStart', function(name)
         local data = LoadResourceFile(GetCurrentResourceName(), 'xmlFiles/' .. Config.ELSFiles[i])
 
         if data then ParseObjSet(data, Config.ELSFiles[i])
-        else error('VCF file not found: ' .. Config.ELSFiles[i]) end
+        else print('VCF file not found: ' .. Config.ELSFiles[i]) end
     end
 
     -- send the ELS data to all clients


### PR DESCRIPTION
Script will now just continue when a specified XML file is not found.

Fixes #13 