### PR TITLE
feat: respect IsElsControlled setting

### DIFF
--- a/resource/client/lights.lua
+++ b/resource/client/lights.lua
@@ -7,9 +7,17 @@ AddEventHandler('kjELS:resetExtras', function(vehicle)
 
     local model = GetDisplayNameFromVehicleModel(GetEntityModel(vehicle))
 
-    if SetContains(kjxmlData, model) then
-        for e = 1, 14 do
-            SetVehicleExtra(vehicle, e, true)
+    if not SetContains(kjxmlData, model) then
+        CancelEvent()
+        return
+    end
+
+    -- loop through all extra's
+    for extra, info in pairs(kjxmlData[model].extras) do
+        -- check if we can control this extra
+        if info.enabled == true then
+            -- disable the extra
+            SetVehicleExtra(vehicle, extra, true)
         end
     end
 end)


### PR DESCRIPTION
Closes #18 

Previously, ALL extra's were disabled when toggling a light state, now it will only disable extras that are 'enabled' in the VCF. This will prevent 'static' extra's for example to disappear when toggling the lights.