### PR TITLE
add: if the vehicle has no vcf or police horn handle.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -35,6 +35,7 @@ local function HandleHorn(vehicle)
     if not PedIsDriver(vehicle) then return end
 
     -- get the horn info from the VCF
+    if kjxmlData[GetCarHash(vehicle)] == nil then return end
     local mainHorn = kjxmlData[GetCarHash(vehicle)].sounds.mainHorn
 
     -- the custom horn is disabled


### PR DESCRIPTION
This stops the full script from breaking on the client