### PR TITLE
fix: disable auto repair when toggling extras

### DIFF
--- a/resource/client/commands.lua
+++ b/resource/client/commands.lua
@@ -17,6 +17,9 @@ AddEventHandler('kjELS:toggleExtra', function(vehicle, extra)
     -- see if the extra is currently on or off
     local toggle = IsVehicleExtraTurnedOn(vehicle, extra)
 
+    -- disable auto repairs
+    SetVehicleAutoRepairDisabled(vehicle, true)
+
     -- toggle the extra
     SetVehicleExtra(vehicle, extra, toggle)
 end)

--- a/resource/client/extras_menu.lua
+++ b/resource/client/extras_menu.lua
@@ -31,6 +31,9 @@ mainMenu.OnCheckboxChange = function(sender, item, checked)
                 return
             end
 
+            -- disable auto repairs
+            SetVehicleAutoRepairDisabled(vehicle, true)
+
             -- toggle the extra
             SetVehicleExtra(vehicle, v[2], checked and 0 or 1)
         end

--- a/resource/client/lights.lua
+++ b/resource/client/lights.lua
@@ -61,30 +61,36 @@ local function SetLightStage(vehicle, stage, toggle)
         while ELSvehicle[stage] do
             -- keep the engine on whilst the lights are activated
             SetVehicleEngineOn(vehicle, true, true, false)
-    
+
             local lastFlash = {}
-    
+
             for _, flash in ipairs(VCFdata.patterns[pattern]) do
                 if ELSvehicle[stage] then
                     for _, extra in ipairs(flash['extras']) do
+                        -- disable auto repairs
+                        SetVehicleAutoRepairDisabled(vehicle, true)
+
                         -- turn the extra on
                         SetVehicleExtra(vehicle, extra, 0)
-    
+
                         -- save the extra as last flashed
                         table.insert(lastFlash, extra)
                     end
-    
+
                     Citizen.Wait(flash.duration)
                 end
-    
+
                 -- turn off the last flashed extras
                 for _, v in ipairs(lastFlash) do
+                    -- disable auto repairs
+                    SetVehicleAutoRepairDisabled(vehicle, true)
+
                     SetVehicleExtra(vehicle, v, 1)
                 end
-    
+
                 lastFlash = {}
             end
-    
+
             Citizen.Wait(0)
         end
 
@@ -110,6 +116,9 @@ AddEventHandler('kjELS:resetExtras', function(vehicle)
     for extra, info in pairs(kjxmlData[model].extras) do
         -- check if we can control this extra
         if info.enabled == true then
+            -- disable auto repairs
+            SetVehicleAutoRepairDisabled(vehicle, true)
+
             -- disable the extra
             SetVehicleExtra(vehicle, extra, true)
         end


### PR DESCRIPTION
Added this because it's recommended [in the docs](https://docs.fivem.net/natives/?_0x5F3A3574). However, it does not seem to do anything.

Referencing #29.