### PR TITLE
feat: only disable siren when all lights are turned off

### DIFF
--- a/resource/client/lights.lua
+++ b/resource/client/lights.lua
@@ -2,8 +2,8 @@ local function SetLightStage(vehicle, stage, toggle)
     local ELSvehicle = kjEnabledVehicles[vehicle]
     local VCFdata = kjxmlData[GetCarHash(vehicle)]
 
-    -- convert the given light stage to a pattern in the VCF
-    local pattern = ConvertStageToPattern(stage)
+    -- get the pattern data
+    local patternData = VCFdata.patterns[ConvertStageToPattern(stage)]
 
     -- reset all extras
     TriggerEvent('kjELS:resetExtras', vehicle)
@@ -11,12 +11,12 @@ local function SetLightStage(vehicle, stage, toggle)
     -- set the light state
     ELSvehicle[stage] = toggle
 
-    if VCFdata.patterns[pattern].isEmergency then
+    if patternData.isEmergency then
         -- toggle the native siren ('emergency mode')
         SetVehicleSiren(vehicle, toggle)
     end
 
-    if (VCFdata.patterns[pattern].flashHighBeam) then
+    if (patternData.flashHighBeam) then
         Citizen.CreateThread(function()
             -- get the current vehicle lights state
             local _, lightsOn, highbeamsOn = GetVehicleLightsState(vehicle)
@@ -45,7 +45,7 @@ local function SetLightStage(vehicle, stage, toggle)
         end)
     end
 
-    if VCFdata.patterns[pattern].enableWarningBeep then
+    if patternData.enableWarningBeep then
         Citizen.CreateThread(function()
             while ELSvehicle[stage] do
                 -- play warning sound
@@ -64,7 +64,7 @@ local function SetLightStage(vehicle, stage, toggle)
 
             local lastFlash = {}
 
-            for _, flash in ipairs(VCFdata.patterns[pattern]) do
+            for _, flash in ipairs(patternData) do
                 if ELSvehicle[stage] then
                     for _, extra in ipairs(flash['extras']) do
                         -- disable auto repairs

--- a/resource/client/main.lua
+++ b/resource/client/main.lua
@@ -70,11 +70,15 @@ local function HandleHorn()
 end
 
 local function ToggleLights(vehicle, stage, toggle)
+    local ELSvehicle = kjEnabledVehicles[vehicle].primary
+
     -- turn light stage on or off based on the toggle
     TriggerEvent('kjELS:toggleLights', vehicle, stage, toggle)
 
-    -- the siren is always off when the lights are toggled
-    TriggerServerEvent('kjELS:setSirenState', 0)
+    -- turn siren off when all lights are off
+    if not ELSvehicle.primary and not ELSvehicle.secondary and not ELSvehicle.warning then
+        TriggerServerEvent('kjELS:setSirenState', 0)
+    end
 end
 
 local function HandleLightStage(stage)


### PR DESCRIPTION
Closes #77 

The siren is now only turned off when there is no light stage active anymore. This means that the siren will stay on when you toggle a second light stage.